### PR TITLE
Skip statements without semantic in semantic filter.

### DIFF
--- a/test/baselines/semi/SemanticFilterTest.java
+++ b/test/baselines/semi/SemanticFilterTest.java
@@ -39,4 +39,16 @@ class Test {
             }
         }
     }
+
+    void tryStatement() {
+        int x = 0;
+        // there will be no pure try statement in extracted semantic dictionary
+        // try statement brings no semantic, but brings blocks, such as main block, catches, etc.
+        try {
+            x /= 0;
+        }
+        catch(ArithmeticException e) {
+
+        }
+    }
 }

--- a/test/baselines/semi/test_semantic_filtering.py
+++ b/test/baselines/semi/test_semantic_filtering.py
@@ -28,6 +28,9 @@ class SemanticFilterTestCase(TestCase):
     def test_extract_deep_nested_break(self):
         self._opportunity_test_helper("deepNestedBreak", [36, 37], True)
 
+    def test_try_statement(self):
+        self._opportunity_test_helper("tryStatement", [44], True)
+
     def _opportunity_test_helper(
         self,
         method_name: str,

--- a/veniq/baselines/semi/_semantic_filter.py
+++ b/veniq/baselines/semi/_semantic_filter.py
@@ -77,7 +77,7 @@ class _SymanticFilterCallbacks:
             ):
                 self._is_control_flow_breaking_statement_out_of_cycle = True
 
-        elif self._is_all_statements_has_been_visited:
+        elif self._is_all_statements_has_been_visited and statement.node in self._statements_semantic:
             statement_semantic = self._statements_semantic[statement.node]
             used_based_objects = statement_semantic.used_based_objects
             self._variable_needed_to_return.update(used_based_objects & self._variables_names_in_statements)


### PR DESCRIPTION
Some statements does not bring any semantic itself, like `block` or `try` statements. Whe should skip them, while checking in semantic filter for used variables.