### PR TITLE
Fixed wrong writing into csv because of wrong encoding

### DIFF
--- a/veniq/dataset_collection/augmentation.py
+++ b/veniq/dataset_collection/augmentation.py
@@ -440,8 +440,8 @@ if __name__ == '__main__':  # noqa: C901
                         i[0] = str(dst_filename.as_posix())
                         #  get local path for inlined filename
                         i[-3] = i[-3].relative_to(os.getcwd()).as_posix()
-                        final_line = [str(element).encode('utf8') for element in i]
-                        writer.writerow(final_line)
+                        i[2] = str(i[2]).encode('utf8')
+                        writer.writerow(i)
                 csvfile.flush()
             except StopIteration:
                 continue

--- a/veniq/dataset_collection/augmentation.py
+++ b/veniq/dataset_collection/augmentation.py
@@ -9,7 +9,7 @@ from argparse import ArgumentParser
 from collections import defaultdict
 from functools import partial
 from pathlib import Path
-from typing import Tuple, Dict, List, Any, Set
+from typing import Tuple, Dict, List, Any, Set, Optional
 
 import pandas as pd
 from pebble import ProcessPool
@@ -286,15 +286,15 @@ def insert_code_with_new_file_creation(
     return line_to_csv
 
 
-def get_ast_if_possibe(file_path: Path) -> AST:
+def get_ast_if_possibe(file_path: Path) -> Optional[AST]:
     """
     Processing file in order to check
     that its original version can be parsed
     """
+    ast = None
     try:
         ast = AST.build_from_javalang(build_ast(str(file_path)))
     except Exception:
-        ast = None
         print(f"Processing {file_path} is aborted due to parsing")
     return ast
 


### PR DESCRIPTION
Fixed issue #50 and sub-problem:
```
  File ".\veniq\dataset_collection\augmentation.py", line 427, in <module>
    writer.writerow(i)
  File "C:\Users\Vitaly\Anaconda3\lib\encodings\cp1251.py", line 19, in encode
    return codecs.charmap_encode(input,self.errors,encoding_table)[0]
UnicodeEncodeError: 'charmap' codec can't encode characters in position 158-161: character maps to <undefined>
```