### PR TITLE
Dataset collection: extract duplicating lines in test_dataset_collection.py

### DIFF
--- a/test/dataset_collection/test_dataset_collection.py
+++ b/test/dataset_collection/test_dataset_collection.py
@@ -18,165 +18,156 @@ from veniq.utils.ast_builder import build_ast
 class TestDatasetCollection(TestCase):
     current_directory = Path(__file__).absolute().parent
 
-    def test_determine_type_without_return_without_arguments(self):
+    def setUp(self):
         filepath = self.current_directory / "Example.java"
-        ast = AST.build_from_javalang(build_ast(filepath))
+        self.ast = AST.build_from_javalang(build_ast(filepath))
+        self.temp_filename = self.current_directory / 'temp.java'
+
+    def tearDown(self):
+        if self.temp_filename.exists():
+            self.temp_filename.unlink()
+
+    def test_determine_type_without_return_without_arguments(self):
         m_decl = [
-            x for x in ast.get_proxy_nodes(ASTNodeType.METHOD_DECLARATION)
+            x for x in self.ast.get_proxy_nodes(ASTNodeType.METHOD_DECLARATION)
             if x.name == 'method'][0]
         m_decl_original = [
-            x for x in ast.get_proxy_nodes(ASTNodeType.METHOD_DECLARATION)
+            x for x in self.ast.get_proxy_nodes(ASTNodeType.METHOD_DECLARATION)
             if x.name == 'method_without_params'][0]
         m_inv = [
-            x for x in ast.get_subtree(m_decl).get_proxy_nodes(ASTNodeType.METHOD_INVOCATION)
+            x for x in self.ast.get_subtree(m_decl).get_proxy_nodes(ASTNodeType.METHOD_INVOCATION)
             if x.member == 'method_without_params'][0]
         d = {'method_without_params': [m_decl_original]}
-        type = determine_algorithm_insertion_type(ast, m_decl, m_inv, d)
+        type = determine_algorithm_insertion_type(self.ast, m_decl, m_inv, d)
         self.assertEqual(type, InlineTypesAlgorithms.WITHOUT_RETURN_WITHOUT_ARGUMENTS)
 
     def test_determine_type_with_return_without_parameters(self):
-        filepath = self.current_directory / "Example.java"
-        ast = AST.build_from_javalang(build_ast(filepath))
         m_decl = [
-            x for x in ast.get_proxy_nodes(ASTNodeType.METHOD_DECLARATION)
+            x for x in self.ast.get_proxy_nodes(ASTNodeType.METHOD_DECLARATION)
             if x.name == 'reset_return_var_decl'][0]
         m_decl_original = [
-            x for x in ast.get_proxy_nodes(ASTNodeType.METHOD_DECLARATION)
+            x for x in self.ast.get_proxy_nodes(ASTNodeType.METHOD_DECLARATION)
             if x.name == 'closeServer_return'][0]
         m_inv = [
-            x for x in ast.get_subtree(m_decl).get_proxy_nodes(ASTNodeType.METHOD_INVOCATION)
+            x for x in self.ast.get_subtree(m_decl).get_proxy_nodes(ASTNodeType.METHOD_INVOCATION)
             if x.member == 'closeServer_return'][0]
         d = {'closeServer_return': [m_decl_original]}
-        type = determine_algorithm_insertion_type(ast, m_decl, m_inv, d)
+        type = determine_algorithm_insertion_type(self.ast, m_decl, m_inv, d)
         self.assertEqual(type, InlineTypesAlgorithms.WITH_RETURN_WITHOUT_ARGUMENTS)
 
     def test_determine_type_with_parameters(self):
-        filepath = self.current_directory / "Example.java"
-        ast = AST.build_from_javalang(build_ast(filepath))
         m_decl = [
-            x for x in ast.get_proxy_nodes(ASTNodeType.METHOD_DECLARATION)
+            x for x in self.ast.get_proxy_nodes(ASTNodeType.METHOD_DECLARATION)
             if x.name == 'some_method'][0]
         m_decl_original = [
-            x for x in ast.get_proxy_nodes(ASTNodeType.METHOD_DECLARATION)
+            x for x in self.ast.get_proxy_nodes(ASTNodeType.METHOD_DECLARATION)
             if x.name == 'method_with_parameters'][0]
         m_inv = [
-            x for x in ast.get_subtree(m_decl).get_proxy_nodes(ASTNodeType.METHOD_INVOCATION)
+            x for x in self.ast.get_subtree(m_decl).get_proxy_nodes(ASTNodeType.METHOD_INVOCATION)
             if x.member == 'method_with_parameters'][0]
         d = {'method_with_parameters': [m_decl_original]}
-        type = determine_algorithm_insertion_type(ast, m_decl, m_inv, d)
+        type = determine_algorithm_insertion_type(self.ast, m_decl, m_inv, d)
         self.assertEqual(type, InlineTypesAlgorithms.DO_NOTHING)
 
     def test_determine_type_with_overridden_functions(self):
-        filepath = self.current_directory / "Example.java"
-        ast = AST.build_from_javalang(build_ast(filepath))
         m_decl = [
-            x for x in ast.get_proxy_nodes(ASTNodeType.METHOD_DECLARATION)
+            x for x in self.ast.get_proxy_nodes(ASTNodeType.METHOD_DECLARATION)
             if x.name == 'invoke_overridden'][0]
         m_decl_original = [
-            x for x in ast.get_proxy_nodes(ASTNodeType.METHOD_DECLARATION)
+            x for x in self.ast.get_proxy_nodes(ASTNodeType.METHOD_DECLARATION)
             if x.name == 'overridden_func']
         m_inv = [
-            x for x in ast.get_subtree(m_decl).get_proxy_nodes(ASTNodeType.METHOD_INVOCATION)
+            x for x in self.ast.get_subtree(m_decl).get_proxy_nodes(ASTNodeType.METHOD_INVOCATION)
             if x.member == 'overridden_func'][0]
         d = {'overridden_func': m_decl_original}
-        type = determine_algorithm_insertion_type(ast, m_decl, m_inv, d)
+        type = determine_algorithm_insertion_type(self.ast, m_decl, m_inv, d)
         self.assertEqual(type, InlineTypesAlgorithms.DO_NOTHING)
 
     def test_determine_type_with_invalid_functions(self):
         """Tests if we have invocation,
         but we didn't find it in the list of method declarations
         in current class."""
-        filepath = self.current_directory / "Example.java"
-        ast = AST.build_from_javalang(build_ast(filepath))
         m_decl = [
-            x for x in ast.get_proxy_nodes(ASTNodeType.METHOD_DECLARATION)
+            x for x in self.ast.get_proxy_nodes(ASTNodeType.METHOD_DECLARATION)
             if x.name == 'invoke_overridden'][0]
         m_decl_original = [
-            x for x in ast.get_proxy_nodes(ASTNodeType.METHOD_DECLARATION)
+            x for x in self.ast.get_proxy_nodes(ASTNodeType.METHOD_DECLARATION)
             if x.name == 'overridden_func']
         m_inv = [
-            x for x in ast.get_subtree(m_decl).get_proxy_nodes(ASTNodeType.METHOD_INVOCATION)
+            x for x in self.ast.get_subtree(m_decl).get_proxy_nodes(ASTNodeType.METHOD_INVOCATION)
             if x.member == 'overridden_func'][0]
         d = {'SOME_RANDOM_NAME': m_decl_original}
-        type = determine_algorithm_insertion_type(ast, m_decl, m_inv, d)
+        type = determine_algorithm_insertion_type(self.ast, m_decl, m_inv, d)
         self.assertEqual(type, InlineTypesAlgorithms.DO_NOTHING)
 
     def test_determine_type_without_variables_declaration(self):
-        filepath = self.current_directory / "Example.java"
-        ast = AST.build_from_javalang(build_ast(filepath))
         m_decl = [
-            x for x in ast.get_proxy_nodes(ASTNodeType.METHOD_DECLARATION)
+            x for x in self.ast.get_proxy_nodes(ASTNodeType.METHOD_DECLARATION)
             if x.name == 'method'][0]
         m_decl_original = [
-            x for x in ast.get_proxy_nodes(ASTNodeType.METHOD_DECLARATION)
+            x for x in self.ast.get_proxy_nodes(ASTNodeType.METHOD_DECLARATION)
             if x.name == 'method_without_params'][0]
         m_inv = [
-            x for x in ast.get_subtree(m_decl).get_proxy_nodes(ASTNodeType.METHOD_INVOCATION)
+            x for x in self.ast.get_subtree(m_decl).get_proxy_nodes(ASTNodeType.METHOD_INVOCATION)
             if x.member == 'method_without_params'][0]
         d = {'method_without_params': [m_decl_original]}
-        type = determine_algorithm_insertion_type(ast, m_decl, m_inv, d)
+        type = determine_algorithm_insertion_type(self.ast, m_decl, m_inv, d)
         self.assertEqual(type, InlineTypesAlgorithms.WITHOUT_RETURN_WITHOUT_ARGUMENTS)
 
         # We consider all cases (with or without return)
         # if there are no variables, declared in invoked function
 
         m_decl = [
-            x for x in ast.get_proxy_nodes(ASTNodeType.METHOD_DECLARATION)
+            x for x in self.ast.get_proxy_nodes(ASTNodeType.METHOD_DECLARATION)
             if x.name == 'method_with_return_not_var_decl'][0]
         m_decl_original = [
-            x for x in ast.get_proxy_nodes(ASTNodeType.METHOD_DECLARATION)
+            x for x in self.ast.get_proxy_nodes(ASTNodeType.METHOD_DECLARATION)
             if x.name == 'closeServer_return'][0]
         m_inv = [
-            x for x in ast.get_subtree(m_decl).get_proxy_nodes(ASTNodeType.METHOD_INVOCATION)
+            x for x in self.ast.get_subtree(m_decl).get_proxy_nodes(ASTNodeType.METHOD_INVOCATION)
             if x.member == 'closeServer_return'][0]
         d = {'closeServer_return': [m_decl_original]}
-        type = determine_algorithm_insertion_type(ast, m_decl, m_inv, d)
+        type = determine_algorithm_insertion_type(self.ast, m_decl, m_inv, d)
 
         self.assertEqual(type, InlineTypesAlgorithms.WITH_RETURN_WITHOUT_ARGUMENTS)
 
     def test_is_invocation_in_if_with_single_statement_valid(self):
-        filepath = self.current_directory / "Example.java"
-        ast = AST.build_from_javalang(build_ast(filepath))
         m_decl = [
-            x for x in ast.get_proxy_nodes(ASTNodeType.METHOD_DECLARATION)
+            x for x in self.ast.get_proxy_nodes(ASTNodeType.METHOD_DECLARATION)
             if x.name == 'test_single_stat_in_if'][0]
         m_decl_original = [
-            x for x in ast.get_proxy_nodes(ASTNodeType.METHOD_DECLARATION)
+            x for x in self.ast.get_proxy_nodes(ASTNodeType.METHOD_DECLARATION)
             if x.name == 'intersected_var'][0]
         m_inv = [
-            x for x in ast.get_subtree(m_decl).get_proxy_nodes(ASTNodeType.METHOD_INVOCATION)
+            x for x in self.ast.get_subtree(m_decl).get_proxy_nodes(ASTNodeType.METHOD_INVOCATION)
             if x.member == 'intersected_var'][0]
 
-        self.assertFalse(is_match_to_the_conditions(ast, m_inv, m_decl_original))
+        self.assertFalse(is_match_to_the_conditions(self.ast, m_inv, m_decl_original))
 
     def test_is_return_type_not_assigning_value_valid(self):
-        filepath = self.current_directory / "Example.java"
-        ast = AST.build_from_javalang(build_ast(filepath))
         m_decl = [
-            x for x in ast.get_proxy_nodes(ASTNodeType.METHOD_DECLARATION)
+            x for x in self.ast.get_proxy_nodes(ASTNodeType.METHOD_DECLARATION)
             if x.name == 'method_decl'][0]
         m_inv = [
-            x for x in ast.get_subtree(m_decl).get_proxy_nodes(ASTNodeType.METHOD_INVOCATION)
+            x for x in self.ast.get_subtree(m_decl).get_proxy_nodes(ASTNodeType.METHOD_INVOCATION)
             if x.member == 'invocation'][0]
         m_decl_original = [
-            x for x in ast.get_proxy_nodes(ASTNodeType.METHOD_DECLARATION)
+            x for x in self.ast.get_proxy_nodes(ASTNodeType.METHOD_DECLARATION)
             if x.name == 'invocation'][0]
-        self.assertFalse(is_match_to_the_conditions(ast, m_inv, m_decl_original))
+        self.assertFalse(is_match_to_the_conditions(self.ast, m_inv, m_decl_original))
 
     def test_determine_type_with_non_intersected_variables_declaration(self):
-        filepath = self.current_directory / "Example.java"
-        ast = AST.build_from_javalang(build_ast(filepath))
         m_decl = [
-            x for x in ast.get_proxy_nodes(ASTNodeType.METHOD_DECLARATION)
+            x for x in self.ast.get_proxy_nodes(ASTNodeType.METHOD_DECLARATION)
             if x.name == 'test_not_intersected_var_decl'][0]
         m_decl_original = [
-            x for x in ast.get_proxy_nodes(ASTNodeType.METHOD_DECLARATION)
+            x for x in self.ast.get_proxy_nodes(ASTNodeType.METHOD_DECLARATION)
             if x.name == 'intersected_var'][0]
         m_inv = [
-            x for x in ast.get_subtree(m_decl).get_proxy_nodes(ASTNodeType.METHOD_INVOCATION)
+            x for x in self.ast.get_subtree(m_decl).get_proxy_nodes(ASTNodeType.METHOD_INVOCATION)
             if x.member == 'intersected_var'][0]
         d = {'intersected_var': [m_decl_original]}
-        type = determine_algorithm_insertion_type(ast, m_decl, m_inv, d)
+        type = determine_algorithm_insertion_type(self.ast, m_decl, m_inv, d)
         self.assertTrue(type in [
             InlineTypesAlgorithms.WITH_RETURN_WITHOUT_ARGUMENTS,
             InlineTypesAlgorithms.WITHOUT_RETURN_WITHOUT_ARGUMENTS])
@@ -191,7 +182,7 @@ class TestDatasetCollection(TestCase):
         """
         algorithm = InlineWithReturnWithoutArguments()
         file = self.current_directory / 'InlineExamples' / 'ReturnTypeUseless.java'
-        temp_filename = self.current_directory / 'temp.java'
+
         test_example = self.current_directory / 'InlineTestExamples' / 'ReturnTypeUseless.java'
         ast = AST.build_from_javalang(build_ast(file))
         m_decl = [
@@ -199,16 +190,14 @@ class TestDatasetCollection(TestCase):
             if x.name == 'invocation'][0]
         body_start_line, body_end_line = method_body_lines(m_decl, file)
 
-        algorithm.inline_function(file, 36, body_start_line, body_end_line, temp_filename)
-        with open(temp_filename, encoding='utf-8') as actual_file, \
+        algorithm.inline_function(file, 36, body_start_line, body_end_line, self.temp_filename)
+        with open(self.temp_filename, encoding='utf-8') as actual_file, \
                 open(test_example, encoding='utf-8') as test_ex:
             self.assertEqual(actual_file.read(), test_ex.read())
-        temp_filename.unlink()
 
     def test_inline_with_return_type(self):
         algorithm = InlineWithReturnWithoutArguments()
         file = self.current_directory / 'InlineExamples' / 'ReaderHandler.java'
-        temp_filename = self.current_directory / 'temp.java'
         test_example = self.current_directory / 'InlineTestExamples' / 'ReaderHandler.java'
         ast = AST.build_from_javalang(build_ast(file))
         m_decl = [
@@ -216,16 +205,14 @@ class TestDatasetCollection(TestCase):
             if x.name == 'getReceiverQueueSize'][0]
         body_start_line, body_end_line = method_body_lines(m_decl, file)
 
-        algorithm.inline_function(file, 76, body_start_line, body_end_line, temp_filename)
-        with open(temp_filename, encoding='utf-8') as actual_file, \
+        algorithm.inline_function(file, 76, body_start_line, body_end_line, self.temp_filename)
+        with open(self.temp_filename, encoding='utf-8') as actual_file, \
                 open(test_example, encoding='utf-8') as test_ex:
             self.assertEqual(test_ex.read(), actual_file.read())
-        temp_filename.unlink()
 
     def test_inline_without_return_type(self):
         algorithm = InlineWithoutReturnWithoutArguments()
         file = self.current_directory / 'InlineExamples' / 'PlanetDialog.java'
-        temp_filename = self.current_directory / 'temp.java'
         test_example = self.current_directory / 'InlineTestExamples' / 'PlanetDialog.java'
         ast = AST.build_from_javalang(build_ast(file))
         m_decl = [
@@ -233,58 +220,50 @@ class TestDatasetCollection(TestCase):
             if x.name == 'makeBloom'][0]
         body_start_line, body_end_line = method_body_lines(m_decl, file)
 
-        algorithm.inline_function(file, 70, body_start_line, body_end_line, temp_filename)
-        with open(temp_filename, encoding='utf-8') as actual_file, \
+        algorithm.inline_function(file, 70, body_start_line, body_end_line, self.temp_filename)
+        with open(self.temp_filename, encoding='utf-8') as actual_file, \
                 open(test_example, encoding='utf-8') as test_ex:
             self.assertEqual(actual_file.read(), test_ex.read())
-        temp_filename.unlink()
 
     def test_is_valid_function_with_several_returns(self):
-        filepath = self.current_directory / "Example.java"
-        ast = AST.build_from_javalang(build_ast(filepath))
         m_decl = [
-            x for x in ast.get_proxy_nodes(ASTNodeType.METHOD_DECLARATION)
+            x for x in self.ast.get_proxy_nodes(ASTNodeType.METHOD_DECLARATION)
             if x.name == 'runSeveralReturns'][0]
         m_decl_original = [
-            x for x in ast.get_proxy_nodes(ASTNodeType.METHOD_DECLARATION)
+            x for x in self.ast.get_proxy_nodes(ASTNodeType.METHOD_DECLARATION)
             if x.name == 'severalReturns'][0]
         m_inv = [
-            x for x in ast.get_subtree(m_decl).get_proxy_nodes(ASTNodeType.METHOD_INVOCATION)
+            x for x in self.ast.get_subtree(m_decl).get_proxy_nodes(ASTNodeType.METHOD_INVOCATION)
             if x.member == 'severalReturns'][0]
-        is_matched = is_match_to_the_conditions(ast, m_inv, m_decl_original)
+        is_matched = is_match_to_the_conditions(self.ast, m_inv, m_decl_original)
         self.assertEqual(is_matched, False)
 
     def test_is_valid_function_with_one_return(self):
-        filepath = self.current_directory / "Example.java"
-        ast = AST.build_from_javalang(build_ast(filepath))
         m_decl = [
-            x for x in ast.get_proxy_nodes(ASTNodeType.METHOD_DECLARATION)
+            x for x in self.ast.get_proxy_nodes(ASTNodeType.METHOD_DECLARATION)
             if x.name == 'runDelete'][0]
         m_decl_original = [
-            x for x in ast.get_proxy_nodes(ASTNodeType.METHOD_DECLARATION)
+            x for x in self.ast.get_proxy_nodes(ASTNodeType.METHOD_DECLARATION)
             if x.name == 'delete'][0]
         m_inv = [
-            x for x in ast.get_subtree(m_decl).get_proxy_nodes(ASTNodeType.METHOD_INVOCATION)
+            x for x in self.ast.get_subtree(m_decl).get_proxy_nodes(ASTNodeType.METHOD_INVOCATION)
             if x.member == 'delete'][0]
-        is_matched = is_match_to_the_conditions(ast, m_inv, m_decl_original)
+        is_matched = is_match_to_the_conditions(self.ast, m_inv, m_decl_original)
         self.assertEqual(is_matched, True)
 
     def test_is_valid_function_with_return_in_the_middle(self):
-        filepath = self.current_directory / "Example.java"
-        ast = AST.build_from_javalang(build_ast(filepath))
         m_decl_original = [
-            x for x in ast.get_proxy_nodes(ASTNodeType.METHOD_DECLARATION)
+            x for x in self.ast.get_proxy_nodes(ASTNodeType.METHOD_DECLARATION)
             if x.name == 'severalReturns'][0]
         m_inv = [
-            x for x in ast.get_proxy_nodes(ASTNodeType.METHOD_INVOCATION)
+            x for x in self.ast.get_proxy_nodes(ASTNodeType.METHOD_INVOCATION)
             if x.member == 'severalReturns'][0]
-        is_matched = is_match_to_the_conditions(ast, m_inv, m_decl_original)
+        is_matched = is_match_to_the_conditions(self.ast, m_inv, m_decl_original)
         self.assertEqual(is_matched, False)
 
     def test_inline_invocation_inside_var_declaration(self):
         filepath = self.current_directory / 'InlineExamples' / 'EntityResolver_cut.java'
         test_filepath = self.current_directory / 'InlineTestExamples' / 'EntityResolver_cut.java'
-        temp_filename = self.current_directory / 'temp.java'
         algorithm_type = InlineTypesAlgorithms.WITH_RETURN_WITHOUT_ARGUMENTS
         algorithm_for_inlining = AlgorithmFactory().create_obj(algorithm_type)
         ast = AST.build_from_javalang(build_ast(filepath))
@@ -293,16 +272,14 @@ class TestDatasetCollection(TestCase):
             if x.name == 'createDocumentBuilderFactory'][0]
         body_start_line, body_end_line = method_body_lines(m_decl, filepath)
         self.assertEqual(body_start_line == 33, body_end_line == 40)
-        algorithm_for_inlining().inline_function(filepath, 22, body_start_line, body_end_line, temp_filename)
-        with open(temp_filename, encoding='utf-8') as actual_file, \
+        algorithm_for_inlining().inline_function(filepath, 22, body_start_line, body_end_line, self.temp_filename)
+        with open(self.temp_filename, encoding='utf-8') as actual_file, \
                 open(test_filepath, encoding='utf-8') as test_ex:
             self.assertEqual(actual_file.read(), test_ex.read())
-        temp_filename.unlink()
 
     def test_inline_inside_invokation_several_lines(self):
         filepath = self.current_directory / 'InlineExamples' / 'AbstractMarshaller_cut.java'
         test_filepath = self.current_directory / 'InlineTestExamples' / 'AbstractMarshaller_cut.java'
-        temp_filename = self.current_directory / 'temp.java'
         algorithm_type = InlineTypesAlgorithms.WITH_RETURN_WITHOUT_ARGUMENTS
         algorithm_for_inlining = AlgorithmFactory().create_obj(algorithm_type)
         ast = AST.build_from_javalang(build_ast(filepath))
@@ -312,16 +289,14 @@ class TestDatasetCollection(TestCase):
         body_start_line, body_end_line = method_body_lines(m_decl, filepath)
         self.assertEqual(body_start_line == 17, body_end_line == 20)
 
-        algorithm_for_inlining().inline_function(filepath, 14, body_start_line, body_end_line, temp_filename)
-        with open(temp_filename, encoding='utf-8') as actual_file, \
+        algorithm_for_inlining().inline_function(filepath, 14, body_start_line, body_end_line, self.temp_filename)
+        with open(self.temp_filename, encoding='utf-8') as actual_file, \
                 open(test_filepath, encoding='utf-8') as test_ex:
             self.assertEqual(actual_file.read(), test_ex.read())
-        temp_filename.unlink()
 
     def test_inline_strange_body1(self):
         filepath = self.current_directory / 'InlineExamples' / 'SkipString.java'
         test_filepath = self.current_directory / 'InlineTestExamples' / 'SkipString.java'
-        temp_filename = self.current_directory / 'temp.java'
         algorithm_type = InlineTypesAlgorithms.WITH_RETURN_WITHOUT_ARGUMENTS
         algorithm_for_inlining = AlgorithmFactory().create_obj(algorithm_type)
         ast = AST.build_from_javalang(build_ast(filepath))
@@ -330,16 +305,14 @@ class TestDatasetCollection(TestCase):
             if x.name == 'getString'][0]
         body_start_line, body_end_line = method_body_lines(m_decl, filepath)
         self.assertEqual(body_start_line == 10, body_end_line == 16)
-        algorithm_for_inlining().inline_function(filepath, 5, body_start_line, body_end_line, temp_filename)
-        with open(temp_filename, encoding='utf-8') as actual_file, \
+        algorithm_for_inlining().inline_function(filepath, 5, body_start_line, body_end_line, self.temp_filename)
+        with open(self.temp_filename, encoding='utf-8') as actual_file, \
                 open(test_filepath, encoding='utf-8') as test_ex:
             self.assertEqual(actual_file.read(), test_ex.read())
-        temp_filename.unlink()
 
     def test_inline_strange_body2(self):
         filepath = self.current_directory / 'InlineExamples' / 'cut.java'
         test_filepath = self.current_directory / 'InlineTestExamples' / 'cut.java'
-        temp_filename = self.current_directory / 'temp1.java'
         algorithm_type = InlineTypesAlgorithms.WITHOUT_RETURN_WITHOUT_ARGUMENTS
         algorithm_for_inlining = AlgorithmFactory().create_obj(algorithm_type)
         ast = AST.build_from_javalang(build_ast(filepath))
@@ -347,8 +320,7 @@ class TestDatasetCollection(TestCase):
             x for x in ast.get_proxy_nodes(ASTNodeType.METHOD_DECLARATION)
             if x.name == 'copy'][0]
         body_start_line, body_end_line = method_body_lines(m_decl, filepath)
-        algorithm_for_inlining().inline_function(filepath, 8, body_start_line, body_end_line, temp_filename)
-        with open(temp_filename, encoding='utf-8') as actual_file, \
+        algorithm_for_inlining().inline_function(filepath, 8, body_start_line, body_end_line, self.temp_filename)
+        with open(self.temp_filename, encoding='utf-8') as actual_file, \
                 open(test_filepath, encoding='utf-8') as test_ex:
             self.assertEqual(actual_file.read(), test_ex.read())
-        temp_filename.unlink()

--- a/test/dataset_collection/test_dataset_collection.py
+++ b/test/dataset_collection/test_dataset_collection.py
@@ -20,7 +20,7 @@ class TestDatasetCollection(TestCase):
 
     def setUp(self):
         filepath = self.current_directory / "Example.java"
-        self.ast = AST.build_from_javalang(build_ast(filepath))
+        self.example_ast = AST.build_from_javalang(build_ast(filepath))
         self.temp_filename = self.current_directory / 'temp.java'
 
     def tearDown(self):
@@ -29,58 +29,58 @@ class TestDatasetCollection(TestCase):
 
     def test_determine_type_without_return_without_arguments(self):
         m_decl = [
-            x for x in self.ast.get_proxy_nodes(ASTNodeType.METHOD_DECLARATION)
+            x for x in self.example_ast.get_proxy_nodes(ASTNodeType.METHOD_DECLARATION)
             if x.name == 'method'][0]
         m_decl_original = [
-            x for x in self.ast.get_proxy_nodes(ASTNodeType.METHOD_DECLARATION)
+            x for x in self.example_ast.get_proxy_nodes(ASTNodeType.METHOD_DECLARATION)
             if x.name == 'method_without_params'][0]
         m_inv = [
-            x for x in self.ast.get_subtree(m_decl).get_proxy_nodes(ASTNodeType.METHOD_INVOCATION)
+            x for x in self.example_ast.get_subtree(m_decl).get_proxy_nodes(ASTNodeType.METHOD_INVOCATION)
             if x.member == 'method_without_params'][0]
         d = {'method_without_params': [m_decl_original]}
-        type = determine_algorithm_insertion_type(self.ast, m_decl, m_inv, d)
+        type = determine_algorithm_insertion_type(self.example_ast, m_decl, m_inv, d)
         self.assertEqual(type, InlineTypesAlgorithms.WITHOUT_RETURN_WITHOUT_ARGUMENTS)
 
     def test_determine_type_with_return_without_parameters(self):
         m_decl = [
-            x for x in self.ast.get_proxy_nodes(ASTNodeType.METHOD_DECLARATION)
+            x for x in self.example_ast.get_proxy_nodes(ASTNodeType.METHOD_DECLARATION)
             if x.name == 'reset_return_var_decl'][0]
         m_decl_original = [
-            x for x in self.ast.get_proxy_nodes(ASTNodeType.METHOD_DECLARATION)
+            x for x in self.example_ast.get_proxy_nodes(ASTNodeType.METHOD_DECLARATION)
             if x.name == 'closeServer_return'][0]
         m_inv = [
-            x for x in self.ast.get_subtree(m_decl).get_proxy_nodes(ASTNodeType.METHOD_INVOCATION)
+            x for x in self.example_ast.get_subtree(m_decl).get_proxy_nodes(ASTNodeType.METHOD_INVOCATION)
             if x.member == 'closeServer_return'][0]
         d = {'closeServer_return': [m_decl_original]}
-        type = determine_algorithm_insertion_type(self.ast, m_decl, m_inv, d)
+        type = determine_algorithm_insertion_type(self.example_ast, m_decl, m_inv, d)
         self.assertEqual(type, InlineTypesAlgorithms.WITH_RETURN_WITHOUT_ARGUMENTS)
 
     def test_determine_type_with_parameters(self):
         m_decl = [
-            x for x in self.ast.get_proxy_nodes(ASTNodeType.METHOD_DECLARATION)
+            x for x in self.example_ast.get_proxy_nodes(ASTNodeType.METHOD_DECLARATION)
             if x.name == 'some_method'][0]
         m_decl_original = [
-            x for x in self.ast.get_proxy_nodes(ASTNodeType.METHOD_DECLARATION)
+            x for x in self.example_ast.get_proxy_nodes(ASTNodeType.METHOD_DECLARATION)
             if x.name == 'method_with_parameters'][0]
         m_inv = [
-            x for x in self.ast.get_subtree(m_decl).get_proxy_nodes(ASTNodeType.METHOD_INVOCATION)
+            x for x in self.example_ast.get_subtree(m_decl).get_proxy_nodes(ASTNodeType.METHOD_INVOCATION)
             if x.member == 'method_with_parameters'][0]
         d = {'method_with_parameters': [m_decl_original]}
-        type = determine_algorithm_insertion_type(self.ast, m_decl, m_inv, d)
+        type = determine_algorithm_insertion_type(self.example_ast, m_decl, m_inv, d)
         self.assertEqual(type, InlineTypesAlgorithms.DO_NOTHING)
 
     def test_determine_type_with_overridden_functions(self):
         m_decl = [
-            x for x in self.ast.get_proxy_nodes(ASTNodeType.METHOD_DECLARATION)
+            x for x in self.example_ast.get_proxy_nodes(ASTNodeType.METHOD_DECLARATION)
             if x.name == 'invoke_overridden'][0]
         m_decl_original = [
-            x for x in self.ast.get_proxy_nodes(ASTNodeType.METHOD_DECLARATION)
+            x for x in self.example_ast.get_proxy_nodes(ASTNodeType.METHOD_DECLARATION)
             if x.name == 'overridden_func']
         m_inv = [
-            x for x in self.ast.get_subtree(m_decl).get_proxy_nodes(ASTNodeType.METHOD_INVOCATION)
+            x for x in self.example_ast.get_subtree(m_decl).get_proxy_nodes(ASTNodeType.METHOD_INVOCATION)
             if x.member == 'overridden_func'][0]
         d = {'overridden_func': m_decl_original}
-        type = determine_algorithm_insertion_type(self.ast, m_decl, m_inv, d)
+        type = determine_algorithm_insertion_type(self.example_ast, m_decl, m_inv, d)
         self.assertEqual(type, InlineTypesAlgorithms.DO_NOTHING)
 
     def test_determine_type_with_invalid_functions(self):
@@ -88,86 +88,86 @@ class TestDatasetCollection(TestCase):
         but we didn't find it in the list of method declarations
         in current class."""
         m_decl = [
-            x for x in self.ast.get_proxy_nodes(ASTNodeType.METHOD_DECLARATION)
+            x for x in self.example_ast.get_proxy_nodes(ASTNodeType.METHOD_DECLARATION)
             if x.name == 'invoke_overridden'][0]
         m_decl_original = [
-            x for x in self.ast.get_proxy_nodes(ASTNodeType.METHOD_DECLARATION)
+            x for x in self.example_ast.get_proxy_nodes(ASTNodeType.METHOD_DECLARATION)
             if x.name == 'overridden_func']
         m_inv = [
-            x for x in self.ast.get_subtree(m_decl).get_proxy_nodes(ASTNodeType.METHOD_INVOCATION)
+            x for x in self.example_ast.get_subtree(m_decl).get_proxy_nodes(ASTNodeType.METHOD_INVOCATION)
             if x.member == 'overridden_func'][0]
         d = {'SOME_RANDOM_NAME': m_decl_original}
-        type = determine_algorithm_insertion_type(self.ast, m_decl, m_inv, d)
+        type = determine_algorithm_insertion_type(self.example_ast, m_decl, m_inv, d)
         self.assertEqual(type, InlineTypesAlgorithms.DO_NOTHING)
 
     def test_determine_type_without_variables_declaration(self):
         m_decl = [
-            x for x in self.ast.get_proxy_nodes(ASTNodeType.METHOD_DECLARATION)
+            x for x in self.example_ast.get_proxy_nodes(ASTNodeType.METHOD_DECLARATION)
             if x.name == 'method'][0]
         m_decl_original = [
-            x for x in self.ast.get_proxy_nodes(ASTNodeType.METHOD_DECLARATION)
+            x for x in self.example_ast.get_proxy_nodes(ASTNodeType.METHOD_DECLARATION)
             if x.name == 'method_without_params'][0]
         m_inv = [
-            x for x in self.ast.get_subtree(m_decl).get_proxy_nodes(ASTNodeType.METHOD_INVOCATION)
+            x for x in self.example_ast.get_subtree(m_decl).get_proxy_nodes(ASTNodeType.METHOD_INVOCATION)
             if x.member == 'method_without_params'][0]
         d = {'method_without_params': [m_decl_original]}
-        type = determine_algorithm_insertion_type(self.ast, m_decl, m_inv, d)
+        type = determine_algorithm_insertion_type(self.example_ast, m_decl, m_inv, d)
         self.assertEqual(type, InlineTypesAlgorithms.WITHOUT_RETURN_WITHOUT_ARGUMENTS)
 
         # We consider all cases (with or without return)
         # if there are no variables, declared in invoked function
 
         m_decl = [
-            x for x in self.ast.get_proxy_nodes(ASTNodeType.METHOD_DECLARATION)
+            x for x in self.example_ast.get_proxy_nodes(ASTNodeType.METHOD_DECLARATION)
             if x.name == 'method_with_return_not_var_decl'][0]
         m_decl_original = [
-            x for x in self.ast.get_proxy_nodes(ASTNodeType.METHOD_DECLARATION)
+            x for x in self.example_ast.get_proxy_nodes(ASTNodeType.METHOD_DECLARATION)
             if x.name == 'closeServer_return'][0]
         m_inv = [
-            x for x in self.ast.get_subtree(m_decl).get_proxy_nodes(ASTNodeType.METHOD_INVOCATION)
+            x for x in self.example_ast.get_subtree(m_decl).get_proxy_nodes(ASTNodeType.METHOD_INVOCATION)
             if x.member == 'closeServer_return'][0]
         d = {'closeServer_return': [m_decl_original]}
-        type = determine_algorithm_insertion_type(self.ast, m_decl, m_inv, d)
+        type = determine_algorithm_insertion_type(self.example_ast, m_decl, m_inv, d)
 
         self.assertEqual(type, InlineTypesAlgorithms.WITH_RETURN_WITHOUT_ARGUMENTS)
 
     def test_is_invocation_in_if_with_single_statement_valid(self):
         m_decl = [
-            x for x in self.ast.get_proxy_nodes(ASTNodeType.METHOD_DECLARATION)
+            x for x in self.example_ast.get_proxy_nodes(ASTNodeType.METHOD_DECLARATION)
             if x.name == 'test_single_stat_in_if'][0]
         m_decl_original = [
-            x for x in self.ast.get_proxy_nodes(ASTNodeType.METHOD_DECLARATION)
+            x for x in self.example_ast.get_proxy_nodes(ASTNodeType.METHOD_DECLARATION)
             if x.name == 'intersected_var'][0]
         m_inv = [
-            x for x in self.ast.get_subtree(m_decl).get_proxy_nodes(ASTNodeType.METHOD_INVOCATION)
+            x for x in self.example_ast.get_subtree(m_decl).get_proxy_nodes(ASTNodeType.METHOD_INVOCATION)
             if x.member == 'intersected_var'][0]
 
-        self.assertFalse(is_match_to_the_conditions(self.ast, m_inv, m_decl_original))
+        self.assertFalse(is_match_to_the_conditions(self.example_ast, m_inv, m_decl_original))
 
     def test_is_return_type_not_assigning_value_valid(self):
         m_decl = [
-            x for x in self.ast.get_proxy_nodes(ASTNodeType.METHOD_DECLARATION)
+            x for x in self.example_ast.get_proxy_nodes(ASTNodeType.METHOD_DECLARATION)
             if x.name == 'method_decl'][0]
         m_inv = [
-            x for x in self.ast.get_subtree(m_decl).get_proxy_nodes(ASTNodeType.METHOD_INVOCATION)
+            x for x in self.example_ast.get_subtree(m_decl).get_proxy_nodes(ASTNodeType.METHOD_INVOCATION)
             if x.member == 'invocation'][0]
         m_decl_original = [
-            x for x in self.ast.get_proxy_nodes(ASTNodeType.METHOD_DECLARATION)
+            x for x in self.example_ast.get_proxy_nodes(ASTNodeType.METHOD_DECLARATION)
             if x.name == 'invocation'][0]
-        self.assertFalse(is_match_to_the_conditions(self.ast, m_inv, m_decl_original))
+        self.assertFalse(is_match_to_the_conditions(self.example_ast, m_inv, m_decl_original))
 
     def test_determine_type_with_non_intersected_variables_declaration(self):
         m_decl = [
-            x for x in self.ast.get_proxy_nodes(ASTNodeType.METHOD_DECLARATION)
+            x for x in self.example_ast.get_proxy_nodes(ASTNodeType.METHOD_DECLARATION)
             if x.name == 'test_not_intersected_var_decl'][0]
         m_decl_original = [
-            x for x in self.ast.get_proxy_nodes(ASTNodeType.METHOD_DECLARATION)
+            x for x in self.example_ast.get_proxy_nodes(ASTNodeType.METHOD_DECLARATION)
             if x.name == 'intersected_var'][0]
         m_inv = [
-            x for x in self.ast.get_subtree(m_decl).get_proxy_nodes(ASTNodeType.METHOD_INVOCATION)
+            x for x in self.example_ast.get_subtree(m_decl).get_proxy_nodes(ASTNodeType.METHOD_INVOCATION)
             if x.member == 'intersected_var'][0]
         d = {'intersected_var': [m_decl_original]}
-        type = determine_algorithm_insertion_type(self.ast, m_decl, m_inv, d)
+        type = determine_algorithm_insertion_type(self.example_ast, m_decl, m_inv, d)
         self.assertTrue(type in [
             InlineTypesAlgorithms.WITH_RETURN_WITHOUT_ARGUMENTS,
             InlineTypesAlgorithms.WITHOUT_RETURN_WITHOUT_ARGUMENTS])
@@ -227,38 +227,38 @@ class TestDatasetCollection(TestCase):
 
     def test_is_valid_function_with_several_returns(self):
         m_decl = [
-            x for x in self.ast.get_proxy_nodes(ASTNodeType.METHOD_DECLARATION)
+            x for x in self.example_ast.get_proxy_nodes(ASTNodeType.METHOD_DECLARATION)
             if x.name == 'runSeveralReturns'][0]
         m_decl_original = [
-            x for x in self.ast.get_proxy_nodes(ASTNodeType.METHOD_DECLARATION)
+            x for x in self.example_ast.get_proxy_nodes(ASTNodeType.METHOD_DECLARATION)
             if x.name == 'severalReturns'][0]
         m_inv = [
-            x for x in self.ast.get_subtree(m_decl).get_proxy_nodes(ASTNodeType.METHOD_INVOCATION)
+            x for x in self.example_ast.get_subtree(m_decl).get_proxy_nodes(ASTNodeType.METHOD_INVOCATION)
             if x.member == 'severalReturns'][0]
-        is_matched = is_match_to_the_conditions(self.ast, m_inv, m_decl_original)
+        is_matched = is_match_to_the_conditions(self.example_ast, m_inv, m_decl_original)
         self.assertEqual(is_matched, False)
 
     def test_is_valid_function_with_one_return(self):
         m_decl = [
-            x for x in self.ast.get_proxy_nodes(ASTNodeType.METHOD_DECLARATION)
+            x for x in self.example_ast.get_proxy_nodes(ASTNodeType.METHOD_DECLARATION)
             if x.name == 'runDelete'][0]
         m_decl_original = [
-            x for x in self.ast.get_proxy_nodes(ASTNodeType.METHOD_DECLARATION)
+            x for x in self.example_ast.get_proxy_nodes(ASTNodeType.METHOD_DECLARATION)
             if x.name == 'delete'][0]
         m_inv = [
-            x for x in self.ast.get_subtree(m_decl).get_proxy_nodes(ASTNodeType.METHOD_INVOCATION)
+            x for x in self.example_ast.get_subtree(m_decl).get_proxy_nodes(ASTNodeType.METHOD_INVOCATION)
             if x.member == 'delete'][0]
-        is_matched = is_match_to_the_conditions(self.ast, m_inv, m_decl_original)
+        is_matched = is_match_to_the_conditions(self.example_ast, m_inv, m_decl_original)
         self.assertEqual(is_matched, True)
 
     def test_is_valid_function_with_return_in_the_middle(self):
         m_decl_original = [
-            x for x in self.ast.get_proxy_nodes(ASTNodeType.METHOD_DECLARATION)
+            x for x in self.example_ast.get_proxy_nodes(ASTNodeType.METHOD_DECLARATION)
             if x.name == 'severalReturns'][0]
         m_inv = [
-            x for x in self.ast.get_proxy_nodes(ASTNodeType.METHOD_INVOCATION)
+            x for x in self.example_ast.get_proxy_nodes(ASTNodeType.METHOD_INVOCATION)
             if x.member == 'severalReturns'][0]
-        is_matched = is_match_to_the_conditions(self.ast, m_inv, m_decl_original)
+        is_matched = is_match_to_the_conditions(self.example_ast, m_inv, m_decl_original)
         self.assertEqual(is_matched, False)
 
     def test_inline_invocation_inside_var_declaration(self):


### PR DESCRIPTION
- moved repeating path specification and file creation and deletion into setUp and tearDown methods of unittest

Only look at test_dataset_collection.py